### PR TITLE
Refactor goal metadata storage to use markdown frontmatter

### DIFF
--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -1,5 +1,6 @@
 import { join } from '@std/path';
 import { ensureDir, exists } from '@std/fs';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { Goal, Task } from './types.ts';
 
 export class FileUtils {
@@ -7,6 +8,40 @@ export class FileUtils {
 
   constructor(goalsDir = './goals') {
     this.goalsDir = goalsDir;
+  }
+
+  private parseFrontmatter(content: string): { frontmatter: any; body: string } {
+    const lines = content.split('\n');
+    if (lines[0] !== '---') {
+      return { frontmatter: {}, body: content };
+    }
+
+    let endIndex = -1;
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i] === '---') {
+        endIndex = i;
+        break;
+      }
+    }
+
+    if (endIndex === -1) {
+      return { frontmatter: {}, body: content };
+    }
+
+    const frontmatterText = lines.slice(1, endIndex).join('\n');
+    const body = lines.slice(endIndex + 1).join('\n').trim();
+
+    try {
+      const frontmatter = parseYaml(frontmatterText) || {};
+      return { frontmatter, body };
+    } catch {
+      return { frontmatter: {}, body: content };
+    }
+  }
+
+  private formatWithFrontmatter(frontmatter: any, body: string): string {
+    const yamlStr = stringifyYaml(frontmatter).trim();
+    return `---\n${yamlStr}\n---\n\n${body}`;
   }
 
   async init(): Promise<void> {
@@ -26,21 +61,75 @@ export class FileUtils {
 
   async saveGoal(goal: Goal): Promise<void> {
     const goalDir = await this.createGoalDirectory(goal.id);
-    const goalFile = join(goalDir, 'goal.json');
-    await Deno.writeTextFile(goalFile, JSON.stringify(goal, null, 2));
+    const goalFile = join(goalDir, 'goal.md');
+    
+    // Prepare frontmatter data
+    const frontmatter = {
+      id: goal.id,
+      name: goal.name,
+      createdDate: goal.createdDate.toISOString(),
+      dueDate: goal.dueDate?.toISOString(),
+      status: goal.status,
+      tasks: goal.tasks,
+      completionPercentage: goal.completionPercentage
+    };
+    
+    // Remove undefined values
+    Object.keys(frontmatter).forEach(key => {
+      if (frontmatter[key] === undefined) {
+        delete frontmatter[key];
+      }
+    });
+    
+    const markdown = this.formatWithFrontmatter(frontmatter, goal.description);
+    await Deno.writeTextFile(goalFile, markdown);
   }
 
   async loadGoal(goalId: string): Promise<Goal | null> {
-    const goalFile = join(this.goalsDir, goalId, 'goal.json');
+    // First try to load from markdown file
+    let goalFile = join(this.goalsDir, goalId, 'goal.md');
+    let usingMarkdown = true;
+    
     if (!await exists(goalFile)) {
-      return null;
+      // Fall back to JSON for backward compatibility during migration
+      goalFile = join(this.goalsDir, goalId, 'goal.json');
+      usingMarkdown = false;
+      if (!await exists(goalFile)) {
+        return null;
+      }
     }
+    
     const content = await Deno.readTextFile(goalFile);
-    const goal = JSON.parse(content);
-    // Convert date strings back to Date objects
-    goal.createdDate = new Date(goal.createdDate);
-    if (goal.dueDate) goal.dueDate = new Date(goal.dueDate);
-    return goal;
+    
+    if (usingMarkdown) {
+      const { frontmatter, body } = this.parseFrontmatter(content);
+      
+      const goal: Goal = {
+        id: frontmatter.id || goalId,
+        name: frontmatter.name || '',
+        description: body,
+        createdDate: new Date(frontmatter.createdDate),
+        dueDate: frontmatter.dueDate ? new Date(frontmatter.dueDate) : undefined,
+        status: frontmatter.status || 'active',
+        tasks: frontmatter.tasks || [],
+        completionPercentage: frontmatter.completionPercentage || 0
+      };
+      
+      return goal;
+    } else {
+      // Legacy JSON loading
+      const goal = JSON.parse(content);
+      goal.createdDate = new Date(goal.createdDate);
+      if (goal.dueDate) goal.dueDate = new Date(goal.dueDate);
+      
+      // Automatically migrate to markdown format
+      await this.saveGoal(goal);
+      
+      // Delete the old JSON file
+      await Deno.remove(goalFile);
+      
+      return goal;
+    }
   }
 
   async listGoals(): Promise<Goal[]> {
@@ -106,42 +195,72 @@ export class FileUtils {
   }
 
   private taskToMarkdown(task: Task): string {
-    let md = `# ${task.title}\n\n`;
-    md += `**Status:** ${task.status}\n`;
-    md += `**Priority:** ${task.priority}\n`;
-    md += `**Difficulty:** ${task.difficulty}/10\n`;
-    md += `**Time Estimate:** ${task.timeEstimate} minutes\n`;
+    // Prepare frontmatter data
+    const frontmatter = {
+      id: task.id,
+      title: task.title,
+      status: task.status,
+      priority: task.priority,
+      difficulty: task.difficulty,
+      timeEstimate: task.timeEstimate,
+      dependencies: task.dependencies.length > 0 ? task.dependencies : undefined,
+      dueDate: task.dueDate?.toISOString().split('T')[0],
+      recommendedStartDate: task.recommendedStartDate?.toISOString().split('T')[0],
+      completedDate: task.completedDate?.toISOString().split('T')[0],
+      parentTask: task.parentTask,
+      subtasks: task.subtasks.length > 0 ? task.subtasks : undefined
+    };
     
-    if (task.dependencies.length > 0) {
-      md += `**Dependencies:** ${task.dependencies.join(', ')}\n`;
-    }
+    // Remove undefined values
+    Object.keys(frontmatter).forEach(key => {
+      if (frontmatter[key] === undefined) {
+        delete frontmatter[key];
+      }
+    });
     
-    if (task.dueDate) {
-      md += `**Due Date:** ${task.dueDate.toISOString().split('T')[0]}\n`;
-    }
-    
-    if (task.recommendedStartDate) {
-      md += `**Recommended Start Date:** ${task.recommendedStartDate.toISOString().split('T')[0]}\n`;
-    }
-    
-    if (task.completedDate) {
-      md += `**Completed Date:** ${task.completedDate.toISOString().split('T')[0]}\n`;
-    }
-    
-    if (task.parentTask) {
-      md += `**Parent Task:** ${task.parentTask}\n`;
-    }
-    
-    if (task.subtasks.length > 0) {
-      md += `**Subtasks:** ${task.subtasks.join(', ')}\n`;
-    }
-    
-    md += `\n## Description\n\n${task.description}\n`;
-    
-    return md;
+    return this.formatWithFrontmatter(frontmatter, task.description);
   }
 
   private markdownToTask(taskId: string, markdown: string): Task {
+    const { frontmatter, body } = this.parseFrontmatter(markdown);
+    
+    // If no frontmatter, fall back to parsing the old format
+    if (Object.keys(frontmatter).length === 0) {
+      return this.legacyMarkdownToTask(taskId, markdown);
+    }
+    
+    const task: Task = {
+      id: frontmatter.id || taskId,
+      title: frontmatter.title || '',
+      description: body,
+      status: frontmatter.status || 'todo',
+      priority: frontmatter.priority || 'medium',
+      difficulty: frontmatter.difficulty || 1,
+      timeEstimate: frontmatter.timeEstimate || 0,
+      dependencies: frontmatter.dependencies || [],
+      subtasks: frontmatter.subtasks || []
+    };
+    
+    if (frontmatter.dueDate) {
+      task.dueDate = new Date(frontmatter.dueDate);
+    }
+    
+    if (frontmatter.recommendedStartDate) {
+      task.recommendedStartDate = new Date(frontmatter.recommendedStartDate);
+    }
+    
+    if (frontmatter.completedDate) {
+      task.completedDate = new Date(frontmatter.completedDate);
+    }
+    
+    if (frontmatter.parentTask) {
+      task.parentTask = frontmatter.parentTask;
+    }
+    
+    return task;
+  }
+
+  private legacyMarkdownToTask(taskId: string, markdown: string): Task {
     const lines = markdown.split('\n');
     const task: Task = {
       id: taskId,


### PR DESCRIPTION
## Summary
- Refactored goal and task metadata storage from JSON and embedded metadata to YAML frontmatter
- Implemented automatic migration from legacy JSON format to markdown with frontmatter  
- Added consistent frontmatter schema for both goals and tasks with backward compatibility

## Test plan
- [x] Goal creation now saves metadata as frontmatter in goal.md files
- [x] Task creation now saves metadata as frontmatter in task markdown files
- [x] Legacy JSON goals are automatically migrated to frontmatter format
- [x] Legacy task markdown files with embedded metadata are still readable
- [x] File reading/writing preserves frontmatter and content integrity
- [x] All existing goal operations work with new frontmatter-based storage

🤖 Generated with [Claude Code](https://claude.ai/code)